### PR TITLE
update to work with flutter 3.16

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,6 +23,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace "com.loichamdi.multipleimagespicker"
     compileSdkVersion 29
 
     defaultConfig {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,6 +37,6 @@ android {
 
 dependencies {
     implementation 'androidx.exifinterface:exifinterface:1.3.1'
-    implementation 'com.sangcomz:FishBun:1.1.1'
+    implementation 'io.github.sangcomz:fishbun:1.1.1'
     implementation 'com.github.bumptech.glide:glide:4.11.0'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,6 +37,6 @@ android {
 
 dependencies {
     implementation 'androidx.exifinterface:exifinterface:1.3.1'
-    implementation 'com.sangcomz:FishBun:0.11.2'
+    implementation 'com.sangcomz:FishBun:1.1.1'
     implementation 'com.github.bumptech.glide:glide:4.11.0'
 }

--- a/android/src/main/java/com/loichamdi/multipleimagespicker/MultipleImagesPickerPlugin.java
+++ b/android/src/main/java/com/loichamdi/multipleimagespicker/MultipleImagesPickerPlugin.java
@@ -23,7 +23,6 @@ import androidx.exifinterface.media.ExifInterface;
 import com.sangcomz.fishbun.FishBun;
 import com.sangcomz.fishbun.FishBunCreator;
 import com.sangcomz.fishbun.adapter.image.impl.GlideAdapter;
-import com.sangcomz.fishbun.define.Define;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -611,7 +610,7 @@ public class MultipleImagesPickerPlugin implements
         if (requestCode == REQUEST_CODE_CHOOSE && resultCode == Activity.RESULT_CANCELED) {
             finishWithError("CANCELLED", "The user has cancelled the selection");
         } else if (requestCode == REQUEST_CODE_CHOOSE && resultCode == Activity.RESULT_OK) {
-            List<Uri> photos = data.getParcelableArrayListExtra(Define.INTENT_PATH);
+            List<Uri> photos = data.getParcelableArrayListExtra(INTENT_PATH);
             if (photos == null) {
                 clearMethodCallAndResult();
                 return false;

--- a/android/src/main/java/com/loichamdi/multipleimagespicker/MultipleImagesPickerPlugin.java
+++ b/android/src/main/java/com/loichamdi/multipleimagespicker/MultipleImagesPickerPlugin.java
@@ -610,7 +610,7 @@ public class MultipleImagesPickerPlugin implements
         if (requestCode == REQUEST_CODE_CHOOSE && resultCode == Activity.RESULT_CANCELED) {
             finishWithError("CANCELLED", "The user has cancelled the selection");
         } else if (requestCode == REQUEST_CODE_CHOOSE && resultCode == Activity.RESULT_OK) {
-            List<Uri> photos = data.getParcelableArrayListExtra(INTENT_PATH);
+            List<Uri> photos = data.getParcelableArrayListExtra(FishBun.INTENT_PATH);
             if (photos == null) {
                 clearMethodCallAndResult();
                 return false;

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -7,7 +7,7 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.2
+  cupertino_icons: ^1.0.6
 
 dev_dependencies:
   flutter_test:

--- a/lib/src/asset_thumb_provider.dart
+++ b/lib/src/asset_thumb_provider.dart
@@ -26,7 +26,7 @@ class AssetThumbImageProvider extends ImageProvider<AssetThumbImageProvider> {
   });
 
   @override
-  ImageStreamCompleter load(AssetThumbImageProvider key, DecoderCallback decode) {
+  ImageStreamCompleter loadImage(AssetThumbImageProvider key, ImageDecoderCallback decode) {
     return new MultiFrameImageStreamCompleter(
       codec: _loadAsync(key),
       scale: key.scale,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: multiple_images_picker
 description: Pick multiple images on iOS and Android.
-version: 1.0.1
+version: 1.1.0
 homepage: https://github.com/loic-hamdi/multiple_images_picker
 
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.8.0
+  meta: ^1.10.0
 
 dev_dependencies:
   flutter_test:
@@ -23,7 +23,5 @@ flutter:
         pluginClass: MultipleImagesPickerPlugin
 
 environment:
-  sdk: '>=2.18.1 <3.0.0'
-  flutter: ">=1.17.0"
-  # sdk: ">=2.12.0 <3.0.0"
-  # flutter: ">=1.12.13"
+  sdk: '>=3.2.0'
+  flutter: ">=3.16.0"


### PR DESCRIPTION
Flutter 3.16 removed `ImageProvider.load` and `DecoderCallback`. See: https://docs.flutter.dev/release/release-notes/release-notes-3.16.0

This change updates to use `loadImage` and to use `ImageDecoderCallback` as the second param.

I also updated the version numbers, but please edit, or let me know if you want them set to something else. I'm no flutter expert.